### PR TITLE
Fix escaping issue which happens when current path contains spaces

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 TARGETDIR=$1
-if test -z $TARGETDIR; then TARGETDIR="."; fi
-./lace.sh 6 > $TARGETDIR/lace.h
-./lace.sh 14 > $TARGETDIR/lace14.h
-sed "s:lace\.h:lace14\.h:g" lace.c > $TARGETDIR/lace14.c
+if test -z "$TARGETDIR"; then TARGETDIR="."; fi
+./lace.sh 6 > "$TARGETDIR/lace.h"
+./lace.sh 14 > "$TARGETDIR/lace14.h"
+sed "s:lace\.h:lace14\.h:g" lace.c > "$TARGETDIR/lace14.c"


### PR DESCRIPTION
The project was located in a directory which contained spaces. Due to missing escaping this resulted in errors when trying to build the project:

```
[ 12%] Generating lace.h, lace14.h, lace14.c
./gen.sh: line 3: test: too many arguments
./gen.sh: line 4: $TARGETDIR/lace.h: ambiguous redirect
./gen.sh: line 5: $TARGETDIR/lace14.h: ambiguous redirect
./gen.sh: line 6: $TARGETDIR/lace14.c: ambiguous redirect
make[2]: *** [CMakeFiles/lace14.dir/build.make:63: lace.h] Error 1
make[1]: *** [CMakeFiles/Makefile2:67: CMakeFiles/lace14.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```